### PR TITLE
Fix affichage page avec colonnes

### DIFF
--- a/docs/_includes/onglets/onglets-composites.html
+++ b/docs/_includes/onglets/onglets-composites.html
@@ -28,19 +28,19 @@
                 </ul>
             </div>
         </div>
-        <div id="id_first" class="js-tabcontent ds44-tabs__content" aria-labelledby="label_id_first">
+        <div id="id_first" class="js-tabcontent ds44-tabs__content ds44-inner-container ds44-xl-margin-tb" aria-labelledby="label_id_first">
             <a name="onglet-1" id="onglet-1"></a>
             <h2 class="visually-hidden">1er onglet</h2>
             {{ include.contenuOngletUn }}
             <p class="ds44-keyboard-show"><a href="#label_id_first">Revenir au premier onglet</a></p>
         </div>
-        <div id="id_second" class="js-tabcontent ds44-tabs__content" aria-labelledby="label_id_second" aria-hidden="true">
+        <div id="id_second" class="js-tabcontent ds44-tabs__content ds44-inner-container ds44-xl-margin-tb" aria-labelledby="label_id_second" aria-hidden="true">
             <a name="onglet-2" id="onglet-2"></a>
             <h2 class="visually-hidden">2e onglet</h2>
             {{ include.contenuOngletDeux }}
             <p class="ds44-keyboard-show"><a href="#label_id_second">Revenir au deuxième onglet</a></p>
         </div>
-        <div id="id_third" class="js-tabcontent ds44-tabs__content" aria-labelledby="label_id_third" aria-hidden="true">
+        <div id="id_third" class="js-tabcontent ds44-tabs__content ds44-inner-container ds44-xl-margin-tb" aria-labelledby="label_id_third" aria-hidden="true">
             <a name="onglet-3" id="onglet-3"></a>
             <h2 class="visually-hidden">3e onglet</h2>
             {{ include.contenuOngletTrois }}

--- a/docs/_includes/onglets/onglets-simples.html
+++ b/docs/_includes/onglets/onglets-simples.html
@@ -13,19 +13,19 @@
                 </li>
             </ul>
         </nav>
-        <div id="id_first" class="js-tabcontent ds44-tabs__content" style='display:none'>
+        <div id="id_first" class="js-tabcontent ds44-tabs__content ds44-inner-container ds44-xl-margin-tb" style='display:none'>
             <a name="onglet-1" id="onglet-1"></a>
             <h2 class="visually-hidden">1er onglet</h2>
             {{ include.contenuOngletUn }}
             <p class="ds44-keyboard-show"><a href="#label_id_first">Revenir au premier onglet</a></p>
         </div>
-        <div id="id_second" class="js-tabcontent ds44-tabs__content" style='display:none'>
+        <div id="id_second" class="js-tabcontent ds44-tabs__content ds44-inner-container ds44-xl-margin-tb" style='display:none'>
             <a name="onglet-2" id="onglet-2"></a>
             <h2 class="visually-hidden">2e onglet</h2>
             {{ include.contenuOngletDeux }}
             <p class="ds44-keyboard-show"><a href="#label_id_second">Revenir au deuxième onglet</a></p>
         </div>
-        <div id="id_third" class="js-tabcontent ds44-tabs__content" style='display:none'>
+        <div id="id_third" class="js-tabcontent ds44-tabs__content ds44-inner-container ds44-xl-margin-tb" style='display:none'>
             <a name="onglet-3" id="onglet-3"></a>
             <h2 class="visually-hidden">3e onglet</h2>
             {{ include.contenuOngletTrois }}

--- a/docs/_variations/page/LA__EntryMenu.html
+++ b/docs/_variations/page/LA__EntryMenu.html
@@ -403,7 +403,7 @@ layout: pattern
                     </ul>
 
                 </div>
-                <div class="col-1 grid-offset ds44-hide-tinyToLarge"></div>
+                <div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
                 <aside class="col-4">
                     {% include boxes/box-std-commune.html %}
 

--- a/docs/_variations/page/LA__article.html
+++ b/docs/_variations/page/LA__article.html
@@ -99,7 +99,7 @@ layout: pattern
 							</section>
 						</div>
 
-						<div class="col-1 grid-offset ds44-hide-tinyToLarge"></div>
+						<div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
 
 						<aside class="col-4">
 							<section class="ds44-box ds44-theme mbm">
@@ -160,7 +160,7 @@ layout: pattern
 							</section>
 						</div>
 
-						<div class="col-1 grid-offset ds44-hide-tinyToLarge"></div>
+						<div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
 
 						<aside class="col-4">
 

--- a/docs/_variations/page/LA__ficheAide.html
+++ b/docs/_variations/page/LA__ficheAide.html
@@ -154,7 +154,7 @@ layout: pattern
 							</p>
 						</div>
 
-						<div class="col-1 grid-offset"></div>
+						<div class="col-1 grid-offset ds44-hide-tiny-to-medium"></div>
 
 						<aside class="col-4">
 							<section class="ds44-box ds44-theme ds44-mb3">

--- a/framework/scss/components/_onglets.scss
+++ b/framework/scss/components/_onglets.scss
@@ -57,7 +57,6 @@
 }
 
 .ds44-tabs__content {
-    padding: $ds44-padding-xxlarge;
     opacity: 1;
     transition: all $ds44-timing-standard ease-in-out;
     position: relative;
@@ -100,10 +99,6 @@
 
     .ds44-navOnglets {
         width: 100%;
-    }
-
-    .ds44-tabs__content {
-        padding: $ds44-padding-xlarge $ds44-padding-base;
     }
 
     .ds44-tabs__list {


### PR DESCRIPTION
- Uniformisation des styles sur les pages ayant un système de colonnage. A mettre à jour sur JCMS. 
- Bien ajouter la classe "ds44-hide-tiny-to-medium" sur la div "col-1 grid-offset" sur les pages ci-joint (article, carrefour, annuaire, candidature, contact)